### PR TITLE
Fix for the UnsupportedOperationException if running analyser 2 or more times in elasticsearch

### DIFF
--- a/src/main/java/org/apache/lucene/analysis/ComboAnalyzer.java
+++ b/src/main/java/org/apache/lucene/analysis/ComboAnalyzer.java
@@ -217,7 +217,7 @@ public class ComboAnalyzer extends Analyzer {
         TokenStream[] lastTokenStreams_local = lastTokenStreams.get();
         ReusableTokenStreamComponents lastComboTokenStream_local = lastComboTokenStream.get();
         if (lastComboTokenStream_local == null)
-            lastComboTokenStream_local = new ReusableTokenStreamComponents();
+            lastComboTokenStream_local = new ReusableTokenStreamComponents(fieldName, this);
 
         // Get sub-TokenStreams from sub-analyzers
         for (int i = subAnalyzers.length-1 ; i >= 0 ; --i) {

--- a/src/main/java/org/apache/lucene/analysis/ReusableTokenStreamComponents.java
+++ b/src/main/java/org/apache/lucene/analysis/ReusableTokenStreamComponents.java
@@ -6,9 +6,13 @@ import java.io.Reader;
 public class ReusableTokenStreamComponents extends Analyzer.TokenStreamComponents {
 
     protected TokenStream sink;
+    private final String fieldName;
+    private final Analyzer analyzer;
 
-    public ReusableTokenStreamComponents() {
+    public ReusableTokenStreamComponents(String fieldName, Analyzer analyzer) {
         super(DummyTokenizer.INSTANCE);
+        this.fieldName = fieldName;
+        this.analyzer = analyzer;
     }
 
     public void setTokenStream(TokenStream sink) {
@@ -17,7 +21,7 @@ public class ReusableTokenStreamComponents extends Analyzer.TokenStreamComponent
 
     @Override
     protected void setReader(Reader reader) throws IOException {
-        throw new UnsupportedOperationException();
+        analyzer.createComponents(fieldName, reader);
     }
 
     @Override

--- a/src/test/java/org/apache/lucene/analysis/TestComboAnalyzer.java
+++ b/src/test/java/org/apache/lucene/analysis/TestComboAnalyzer.java
@@ -20,6 +20,7 @@ package org.apache.lucene.analysis;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -126,4 +127,16 @@ public class TestComboAnalyzer extends BaseTokenStreamTestCase {
                     new int[]{ 1,  0,  0,  0,  1,  1,  0,  1,  0,  1,  0});
     }
 
+
+    @Test
+    public void testCanUseFromNamedAnalyzer() throws IOException {
+        ComboAnalyzer cb = new ComboAnalyzer(TEST_VERSION_CURRENT, new WhitespaceAnalyzer(TEST_VERSION_CURRENT));
+        NamedAnalyzer namedAnalyzer = new NamedAnalyzer("name", cb);
+        for (int i = 0 ; i < 3 ; i++)
+            assertTokenStreamContents(namedAnalyzer.tokenStream("field", new StringReader("just a little test "+i)),
+                    new String[]{"just", "a", "little", "test", Integer.toString(i)},
+                    new int[]{ 0,  5,  7, 14, 19},
+                    new int[]{ 4,  6, 13, 18, 20},
+                    new int[]{ 1,  1,  1,  1,  1});
+    }
 }


### PR DESCRIPTION
Fix for issues #6 and #7.

The problem is that the analyser is not able to run more than once inside elasticsearch.

The issue stems from that analysers specified in elasticsearch are always wrapped in a NamedAnalyser, which inherit from a CustomAnalyzerWrapper, which in turn specifies a PerFieldReuseStrategy. 

This is problematic since the ComboAnalyzer assumes that the ReuseStrategy always returns null, thusly modifying the control flow in the Analyzer base class (the tokenStream method).

This fix is forces the plugin to perform the same operation if the ReuseStrategy returns an actual value; instead of throwing on UnsupportedOperationException, it calls the createComponents method. 

I am fully aware that the fix is a bit hacky, and it is only tested for a small amount of sequential calls.
