### PR TITLE
Made compatible with lucene 4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.yakaz.elasticsearch.plugins</groupId>
     <artifactId>elasticsearch-analysis-combo</artifactId>
-    <version>1.3.2-SNAPSHOT</version>
+    <version>1.3.2-lucene4.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <inceptionYear>2011</inceptionYear>
     <licenses>
@@ -38,8 +38,8 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>0.90.0.Beta1</elasticsearch.version>
-        <lucene.version>4.1.0</lucene.version>
+        <elasticsearch.version>0.90.5</elasticsearch.version>
+        <lucene.version>4.4.0</lucene.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/apache/lucene/analysis/ReusableStringReaderCloner.java
+++ b/src/main/java/org/apache/lucene/analysis/ReusableStringReaderCloner.java
@@ -17,8 +17,9 @@
  * under the License.
  */
 
-package org.apache.lucene.document;
+package org.apache.lucene.analysis;
 
+import org.apache.lucene.document.Field;
 import org.apache.lucene.util.ReaderCloneFactory;
 
 import java.io.IOException;
@@ -26,7 +27,7 @@ import java.io.Reader;
 import java.io.StringReader;
 
 /**
- * A ReaderCloner specialized in duplicating Lucene's {@link org.apache.lucene.document.Field.ReusableStringReader}.
+ * A ReaderCloner specialized in duplicating Lucene's {@link org.apache.lucene.analysis.ReusableStringReader}.
  *
  * As this class is package private, this cloner has an additional function
  * to perform an {@code instanceof} check for you.
@@ -35,16 +36,16 @@ import java.io.StringReader;
  * private field {@code String s}, storing the original content.
  * It is therefore sensitive to Lucene implementation changes.
  */
-public class ReusableStringReaderCloner implements ReaderCloneFactory.ReaderCloner<Field.ReusableStringReader> {
+public class ReusableStringReaderCloner implements ReaderCloneFactory.ReaderCloner<ReusableStringReader> {
 
     private static java.lang.reflect.Field internalField;
 
-    private Field.ReusableStringReader original;
+    private ReusableStringReader original;
     private String originalContent;
 
     static {
         try {
-            internalField = Field.ReusableStringReader.class.getDeclaredField("s");
+            internalField = ReusableStringReader.class.getDeclaredField("s");
             internalField.setAccessible(true);
         } catch (Exception ex) {
             throw new IllegalArgumentException("Could not give accessibility to private \"str\" field of the given StringReader", ex);
@@ -52,17 +53,17 @@ public class ReusableStringReaderCloner implements ReaderCloneFactory.ReaderClon
     }
 
     /**
-     * Binds this ReaderCloner with the package-private {@link Field.ReusableStringReader} class
+     * Binds this ReaderCloner with the package-private {@link ReusableStringReader} class
      * into the {@link ReaderCloneFactory}, without giving access to the hidden class.
      */
     public static void registerCloner() {
-        ReaderCloneFactory.bindCloner(Field.ReusableStringReader.class, ReusableStringReaderCloner.class);
+        ReaderCloneFactory.bindCloner(ReusableStringReader.class, ReusableStringReaderCloner.class);
     }
 
     /**
      * @param originalReader Must pass the canHandleReader(Reader) test, otherwise an IllegalArgumentException will be thrown.
      */
-    public void init(Field.ReusableStringReader originalReader) throws IOException {
+    public void init(ReusableStringReader originalReader) throws IOException {
         this.original = originalReader;
         this.originalContent = null;
         try {

--- a/src/main/java/org/apache/lucene/util/ReaderCloneFactory.java
+++ b/src/main/java/org/apache/lucene/util/ReaderCloneFactory.java
@@ -17,7 +17,7 @@
 
 package org.apache.lucene.util;
 
-import org.apache.lucene.document.ReusableStringReaderCloner;
+import org.apache.lucene.analysis.ReusableStringReaderCloner;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 

--- a/src/test/java/org/apache/lucene/analysis/ReusableStringReaderClonerTests.java
+++ b/src/test/java/org/apache/lucene/analysis/ReusableStringReaderClonerTests.java
@@ -1,5 +1,7 @@
-package org.apache.lucene.document;
+package org.apache.lucene.analysis;
 
+import org.apache.lucene.analysis.ReusableStringReaderCloner;
+import org.apache.lucene.document.Field;
 import org.testng.annotations.Test;
 
 import javax.util.ReaderContent;
@@ -16,7 +18,7 @@ public class ReusableStringReaderClonerTests {
     @Test
     public void test() throws Exception {
         String content = "test\n";
-        Field.ReusableStringReader reader = new Field.ReusableStringReader();
+        ReusableStringReader reader = new ReusableStringReader();
         reader.setValue(content);
         ReusableStringReaderCloner cloner = new ReusableStringReaderCloner();
         cloner.init(reader);
@@ -37,7 +39,7 @@ public class ReusableStringReaderClonerTests {
     @Test
     public void testReuseAfterUse() throws Exception {
         String content = "test\n";
-        Field.ReusableStringReader reader = new Field.ReusableStringReader();
+        ReusableStringReader reader = new ReusableStringReader();
         reader.setValue(content);
         ReusableStringReaderCloner cloner = new ReusableStringReaderCloner();
         cloner.init(reader);
@@ -63,7 +65,7 @@ public class ReusableStringReaderClonerTests {
     @Test
     public void testReuseBeforeUse() throws Exception {
         String content = "test\n";
-        Field.ReusableStringReader reader = new Field.ReusableStringReader();
+        ReusableStringReader reader = new ReusableStringReader();
         reader.setValue(content);
         ReusableStringReaderCloner cloner = new ReusableStringReaderCloner();
         cloner.init(reader);

--- a/src/test/java/org/apache/lucene/analysis/TestReusableStringReaderCloner.java
+++ b/src/test/java/org/apache/lucene/analysis/TestReusableStringReaderCloner.java
@@ -15,9 +15,11 @@
  * limitations under the License.
  */
 
-package org.apache.lucene.document;
+package org.apache.lucene.analysis;
 
 import org.apache.lucene.analysis.BaseTokenStreamTestCase;
+import org.apache.lucene.analysis.ReusableStringReaderCloner;
+import org.apache.lucene.document.Field;
 import org.apache.lucene.util.ReaderCloneFactory;
 import org.testng.annotations.Test;
 
@@ -27,7 +29,7 @@ import java.io.Reader;
 import static javax.util.ReaderContent.assertReaderContent;
 
 /**
- * Testcase for {@link org.apache.lucene.document.ReusableStringReaderCloner}
+ * Testcase for {@link org.apache.lucene.analysis.ReusableStringReaderCloner}
  */
 @Test
 public class TestReusableStringReaderCloner extends BaseTokenStreamTestCase {
@@ -39,7 +41,7 @@ public class TestReusableStringReaderCloner extends BaseTokenStreamTestCase {
         // (and it's a real pain to use Java reflection to gain access to
         //  a package private constructor)
         Reader clone;
-        Field.ReusableStringReader reader = new Field.ReusableStringReader();
+        ReusableStringReader reader = new ReusableStringReader();
         reader.setValue("test string");
         ReaderCloneFactory.ReaderCloner<Reader> cloner = ReaderCloneFactory.getCloner(reader);
         assertNotNull(cloner);
@@ -50,7 +52,7 @@ public class TestReusableStringReaderCloner extends BaseTokenStreamTestCase {
         assertReaderContent(clone, "test string");
 
         // Test reusability
-        ReaderCloneFactory.ReaderCloner<Field.ReusableStringReader> forClassClonerStrict = ReaderCloneFactory.getClonerStrict(Field.ReusableStringReader.class);
+        ReaderCloneFactory.ReaderCloner<ReusableStringReader> forClassClonerStrict = ReaderCloneFactory.getClonerStrict(ReusableStringReader.class);
         assertNotNull(forClassClonerStrict);
         assertEquals(forClassClonerStrict.getClass().getName(), ReusableStringReaderCloner.class.getName());
         reader.setValue("another test string");
@@ -66,7 +68,7 @@ public class TestReusableStringReaderCloner extends BaseTokenStreamTestCase {
         clone = forClassClonerStrict.giveAClone();
         assertReaderContent(clone, "test string");
 
-        ReaderCloneFactory.ReaderCloner<Reader> forClassCloner = ReaderCloneFactory.getCloner(Field.ReusableStringReader.class);
+        ReaderCloneFactory.ReaderCloner<Reader> forClassCloner = ReaderCloneFactory.getCloner(ReusableStringReader.class);
         assertNotNull(forClassCloner);
         assertEquals(forClassCloner.getClass().getName(), ReusableStringReaderCloner.class.getName());
         reader.setValue("another test string");


### PR DESCRIPTION
In lucene 4.4 (which the latest release of elasticsearch (0.90.5) depends on, the ReusableStringReader has been refactored out from the Field class, and changed it's package to the analysis.

This pull request contains the fixes needed to get the plugin to build with lucene 4.4. There are also some changes in the pom regarding versions to keep these apart, but I suspect that you will want to change that =)

Thanks for maintaining this project!
